### PR TITLE
Ft/validation

### DIFF
--- a/HackneyAddressesAPI/Controllers/V1/SearchAddressController.cs
+++ b/HackneyAddressesAPI/Controllers/V1/SearchAddressController.cs
@@ -12,6 +12,7 @@ using System;
 using System.Collections.Generic;
 using LBHAddressesAPI.Infrastructure.V1.Validation;
 using LBHAddressesAPI.Validation;
+using LBHAddressesAPI.Infrastructure.V1.Exceptions;
 
 namespace LBHAddressesAPI.Controllers.V1
 {
@@ -40,6 +41,7 @@ namespace LBHAddressesAPI.Controllers.V1
         /// <param name="request"></param>
         /// <returns></returns>
         [ProducesResponseType(typeof(APIResponse<SearchAddressResponse>), 200)]
+        [ProducesResponseType(typeof(APIResponse<BadRequestException>), 400)]
         [HttpGet, MapToApiVersion("1")]       
         public async Task<IActionResult> GetAddresses([FromQuery] SearchAddressRequest request)
         {
@@ -70,7 +72,7 @@ namespace LBHAddressesAPI.Controllers.V1
             }
             else
             {
-                return new BadRequestResult();
+                return new BadRequestObjectResult(new APIResponse<BadRequestException>(new BadRequestException(new RequestValidationResponse(validationResults))));
             }
         }
 

--- a/HackneyAddressesAPI/Controllers/V1/SearchAddressController.cs
+++ b/HackneyAddressesAPI/Controllers/V1/SearchAddressController.cs
@@ -64,13 +64,6 @@ namespace LBHAddressesAPI.Controllers.V1
                     }
                     request.Errors = errors;
                 }
-                //var requestFields = new List<string>();
-                //foreach(var qs in Request.Query)
-                //{
-                //    requestFields.Add(qs.Key);
-                //}
-
-                //request.RequestFields = requestFields;
 
                 var response = await _searchAddressUseCase.ExecuteAsync(request, HttpContext.GetCancellationToken()).ConfigureAwait(false);
                 return HandleResponse(response);

--- a/HackneyAddressesAPI/Exceptions/MissingEnvironmentVariableException.cs
+++ b/HackneyAddressesAPI/Exceptions/MissingEnvironmentVariableException.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace LBHAddressesAPI.Exceptions
+{
+    public class MissingEnvironmentVariableException : Exception
+    {
+        public MissingEnvironmentVariableException(string message) : base(message)
+        {
+
+        }
+    }
+}

--- a/HackneyAddressesAPI/Helpers/GlobalConstants.cs
+++ b/HackneyAddressesAPI/Helpers/GlobalConstants.cs
@@ -32,7 +32,6 @@ namespace LBHAddressesAPI.Helpers
         public enum Gazetteer
         {
             Local,
-            National,
             Both
         };
 

--- a/HackneyAddressesAPI/Properties/launchSettings.json
+++ b/HackneyAddressesAPI/Properties/launchSettings.json
@@ -16,6 +16,7 @@
         "LLPGConnectionStringx": "server=localhost,6666; database=StubAdd; User Id=sa;Password=Rooty-Tooty;",
         "NEW_RELIC_LICENSE_KEY": "0d32e73e3f0a3af7af955009117b97e77cd10752",
         "NEW_RELIC_APP_NAME": "AddressAPI",
+        "ALLOWED_ADDRESSSTATUS_VALUES": "historical;alternative;approved preferred;provisional",
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },

--- a/HackneyAddressesAPI/UseCases/V1/Search/Models/SearchAddressRequest.cs
+++ b/HackneyAddressesAPI/UseCases/V1/Search/Models/SearchAddressRequest.cs
@@ -15,6 +15,11 @@ namespace LBHAddressesAPI.UseCases.V1.Search.Models
     public class SearchAddressRequest : IRequest, IPagedRequest
     {
 
+        public SearchAddressRequest()
+        {
+            this.AddressStatus = "approved preferred";
+        }
+
         //    [FromQuery]string PropertyClassCode = null/*,
         // Parent shells??
 

--- a/HackneyAddressesAPI/UseCases/V1/Search/Models/SearchAddressRequest.cs
+++ b/HackneyAddressesAPI/UseCases/V1/Search/Models/SearchAddressRequest.cs
@@ -139,12 +139,7 @@ namespace LBHAddressesAPI.UseCases.V1.Search.Models
 
                     return new RequestValidationResponse(valRes);
                 }
-            }
-
-            if(castedRequest.UPRN == null && castedRequest.USRN == null && castedRequest.PostCode == null && castedRequest.Street == null && castedRequest.BuildingNumber == null)
-            {
-                return new RequestValidationResponse(false, "No filter parameters have been provided");
-            }
+            }            
 
             //List<string> invalidFields = InvalidFields(castedRequest.RequestFields);
 

--- a/HackneyAddressesAPI/Validation/ISearchAddressValidator.cs
+++ b/HackneyAddressesAPI/Validation/ISearchAddressValidator.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace LBHAddressesAPI.Validation
+{
+    public interface ISearchAddressValidator
+    {
+    }
+}

--- a/HackneyAddressesAPI/Validation/SearchAddressValidator.cs
+++ b/HackneyAddressesAPI/Validation/SearchAddressValidator.cs
@@ -4,14 +4,39 @@ using System.Linq;
 using System.Threading.Tasks;
 using FluentValidation;
 using LBHAddressesAPI.UseCases.V1.Search.Models;
+using LBHAddressesAPI.Exceptions;
 
 namespace LBHAddressesAPI.Validation
 {
     public class SearchAddressValidator : AbstractValidator<SearchAddressRequest>, ISearchAddressValidator
     {
+        private readonly string[] allowedAddressStatusValues;
+
         public SearchAddressValidator()
         {
+            try { allowedAddressStatusValues = Environment.GetEnvironmentVariable("ALLOWED_ADDRESSSTATUS_VALUES").Split(";"); }
+            catch (Exception) { throw new MissingEnvironmentVariableException("ALLOWED_ADDRESSSTATUS_VALUES"); }
+
             RuleFor(r => r.AddressStatus).NotNull().NotEmpty();
+            RuleFor(r => r.AddressStatus).Must(CanBeAnyCombinationOfAllowedValues).WithMessage("Value for the parameter is not valid.");
+        }
+
+        private bool CanBeAnyCombinationOfAllowedValues(string addressStatus)
+        {
+            if(string.IsNullOrEmpty(addressStatus))
+            {
+                return false;
+            }
+            var separateValuesArray = addressStatus.Split(",");
+
+            foreach(string value in separateValuesArray)
+            {
+                if (!allowedAddressStatusValues.Contains(value))
+                {
+                    return false;
+                }
+            }
+            return true;
         }
     }
 }

--- a/HackneyAddressesAPI/Validation/SearchAddressValidator.cs
+++ b/HackneyAddressesAPI/Validation/SearchAddressValidator.cs
@@ -2,10 +2,16 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using FluentValidation;
+using LBHAddressesAPI.UseCases.V1.Search.Models;
 
 namespace LBHAddressesAPI.Validation
 {
-    public class SearchAddressValidator : ISearchAddressValidator
+    public class SearchAddressValidator : AbstractValidator<SearchAddressRequest>, ISearchAddressValidator
     {
+        public SearchAddressValidator()
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/HackneyAddressesAPI/Validation/SearchAddressValidator.cs
+++ b/HackneyAddressesAPI/Validation/SearchAddressValidator.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using FluentValidation;
 using LBHAddressesAPI.UseCases.V1.Search.Models;
 using LBHAddressesAPI.Exceptions;
+using System.Text.RegularExpressions;
 
 namespace LBHAddressesAPI.Validation
 {
@@ -19,6 +20,10 @@ namespace LBHAddressesAPI.Validation
 
             RuleFor(r => r.AddressStatus).NotNull().NotEmpty();
             RuleFor(r => r.AddressStatus).Must(CanBeAnyCombinationOfAllowedValues).WithMessage("Value for the parameter is not valid.");
+
+            RuleFor(r => r.PostCode).NotNull().NotEmpty();
+            RuleFor(r => r.PostCode).Matches(new Regex("^([Gg][Ii][Rr] 0[Aa]{2})|((([A-Za-z][0-9]{1,2})|(([A-Za-z][A-Ha-hJ-Yj-y][0-9]{1,2})|(([A-Za-z][0-9][A-Za-z])|([A-Za-z][A-Ha-hJ-Yj-y][0-9]?[A-Za-z]))))( )?([0-9][A-Za-z]{2})?)$")).WithMessage("Must provide at least the first part of the postcode.");
+
         }
 
         private bool CanBeAnyCombinationOfAllowedValues(string addressStatus)

--- a/HackneyAddressesAPI/Validation/SearchAddressValidator.cs
+++ b/HackneyAddressesAPI/Validation/SearchAddressValidator.cs
@@ -21,9 +21,19 @@ namespace LBHAddressesAPI.Validation
             RuleFor(r => r.AddressStatus).NotNull().NotEmpty();
             RuleFor(r => r.AddressStatus).Must(CanBeAnyCombinationOfAllowedValues).WithMessage("Value for the parameter is not valid.");
 
-            RuleFor(r => r.PostCode).NotNull().NotEmpty();
             RuleFor(r => r.PostCode).Matches(new Regex("^([Gg][Ii][Rr] 0[Aa]{2})|((([A-Za-z][0-9]{1,2})|(([A-Za-z][A-Ha-hJ-Yj-y][0-9]{1,2})|(([A-Za-z][0-9][A-Za-z])|([A-Za-z][A-Ha-hJ-Yj-y][0-9]?[A-Za-z]))))( )?([0-9][A-Za-z]{2})?)$")).WithMessage("Must provide at least the first part of the postcode.");
 
+            RuleFor(r => r).Must(CheckForAtLeastOneMandatoryFilterProperty).WithMessage("You must provide at least one of (UPRN, USRN, Post code, Street)");
+
+        }
+
+        private bool CheckForAtLeastOneMandatoryFilterProperty(SearchAddressRequest request)
+        {
+            if (request.UPRN == null && request.USRN == null && request.PostCode == null && request.Street == null)
+            {
+                return false;
+            }
+            return true;
         }
 
         private bool CanBeAnyCombinationOfAllowedValues(string addressStatus)

--- a/HackneyAddressesAPI/Validation/SearchAddressValidator.cs
+++ b/HackneyAddressesAPI/Validation/SearchAddressValidator.cs
@@ -11,7 +11,7 @@ namespace LBHAddressesAPI.Validation
     {
         public SearchAddressValidator()
         {
-            throw new NotImplementedException();
+            RuleFor(r => r.AddressStatus).NotNull().NotEmpty();
         }
     }
 }

--- a/HackneyAddressesAPI/Validation/SearchAddressValidator.cs
+++ b/HackneyAddressesAPI/Validation/SearchAddressValidator.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace LBHAddressesAPI.Validation
+{
+    public class SearchAddressValidator : ISearchAddressValidator
+    {
+    }
+}

--- a/LBHAddressesAPITest/LBHAddressesAPITest.csproj
+++ b/LBHAddressesAPITest/LBHAddressesAPITest.csproj
@@ -11,6 +11,8 @@
     <PackageReference Include="DotNetEnv" Version="1.2.0" />
     <PackageReference Include="FluentAssertions" Version="5.6.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>

--- a/LBHAddressesAPITest/Test/Controllers/V1/SearchAddressControllerTests.cs
+++ b/LBHAddressesAPITest/Test/Controllers/V1/SearchAddressControllerTests.cs
@@ -43,7 +43,7 @@ namespace LBHAddressesAPITest.Test.Controllers.V1
 
             var request = new SearchAddressRequest
             {
-                PostCode = "",
+                PostCode = "RM3 0FS",
                 Gazetteer = GlobalConstants.Gazetteer.Local
             };
             //act
@@ -57,7 +57,7 @@ namespace LBHAddressesAPITest.Test.Controllers.V1
         }
 
         [Fact]
-        public async Task GivenInvalidSearchAddressRequest_WhenCallingGet_ThenShouldReturnBadRequestResponse()
+        public async Task GivenInvalidSearchAddressRequest_WhenCallingGet_ThenShouldReturnBadRequestObjectResponse()
         {
             //arrange
             var request = new SearchAddressRequest() { AddressStatus = null };
@@ -67,7 +67,7 @@ namespace LBHAddressesAPITest.Test.Controllers.V1
 
             //assert
             response.Should().NotBeNull();
-            response.Should().BeOfType<BadRequestResult>();
+            response.Should().BeOfType<BadRequestObjectResult>();
         }
     }
 }

--- a/LBHAddressesAPITest/Test/Controllers/V1/SearchAddressControllerTests.cs
+++ b/LBHAddressesAPITest/Test/Controllers/V1/SearchAddressControllerTests.cs
@@ -54,5 +54,19 @@ namespace LBHAddressesAPITest.Test.Controllers.V1
             var getAddresses = objectResult?.Value as APIResponse<SearchAddressResponse>;
             getAddresses.Should().NotBeNull();
         }
+
+        [Fact]
+        public async Task GivenInvalidSearchAddressRequest_WhenCallingGet_ThenShouldReturnBadRequestResponse()
+        {
+            //arrange
+            var request = new SearchAddressRequest() { AddressStatus = "Rubbish" };
+
+            //act
+            var response = await _classUnderTest.GetAddresses(request);
+
+            //assert
+            response.Should().NotBeNull();
+            response.Should().BeOfType<BadRequestResult>();
+        }
     }
 }

--- a/LBHAddressesAPITest/Test/Controllers/V1/SearchAddressControllerTests.cs
+++ b/LBHAddressesAPITest/Test/Controllers/V1/SearchAddressControllerTests.cs
@@ -23,6 +23,7 @@ namespace LBHAddressesAPITest.Test.Controllers.V1
 
         public SearchAddressControllerTests()
         {
+            Environment.SetEnvironmentVariable("ALLOWED_ADDRESSSTATUS_VALUES", "historical;alternative;approved preferred;provisional");
             _mock = new Mock<ISearchAddressUseCase>();
             _classUnderTest = new SearchAddressController(_mock.Object);
         }

--- a/LBHAddressesAPITest/Test/Controllers/V1/SearchAddressControllerTests.cs
+++ b/LBHAddressesAPITest/Test/Controllers/V1/SearchAddressControllerTests.cs
@@ -28,8 +28,11 @@ namespace LBHAddressesAPITest.Test.Controllers.V1
             _classUnderTest = new SearchAddressController(_mock.Object);
         }
 
-        [Fact]
-        public async Task GivenValidSearchAddressRequest_WhenCallingGet_ThenShouldReturnAPIResponseListOfAddresses()
+
+        [Theory]
+        [InlineData("RM3 0FS", GlobalConstants.Gazetteer.Local)]
+        [InlineData("IG11 7QD", GlobalConstants.Gazetteer.Both)]
+        public async Task GivenValidSearchAddressRequest_WhenCallingGet_ThenShouldReturnAPIResponseListOfAddresses(string postcode, GlobalConstants.Gazetteer gazetteer)
         {
             //arrange
             _mock.Setup(s => s.ExecuteAsync(It.IsAny<SearchAddressRequest>(), CancellationToken.None))
@@ -43,8 +46,8 @@ namespace LBHAddressesAPITest.Test.Controllers.V1
 
             var request = new SearchAddressRequest
             {
-                PostCode = "RM3 0FS",
-                Gazetteer = GlobalConstants.Gazetteer.Local
+                PostCode = postcode,
+                Gazetteer = gazetteer
             };
             //act
             var response = await _classUnderTest.GetAddresses(request).ConfigureAwait(false);

--- a/LBHAddressesAPITest/Test/Controllers/V1/SearchAddressControllerTests.cs
+++ b/LBHAddressesAPITest/Test/Controllers/V1/SearchAddressControllerTests.cs
@@ -59,7 +59,7 @@ namespace LBHAddressesAPITest.Test.Controllers.V1
         public async Task GivenInvalidSearchAddressRequest_WhenCallingGet_ThenShouldReturnBadRequestResponse()
         {
             //arrange
-            var request = new SearchAddressRequest() { AddressStatus = "Rubbish" };
+            var request = new SearchAddressRequest() { AddressStatus = null };
 
             //act
             var response = await _classUnderTest.GetAddresses(request);

--- a/LBHAddressesAPITest/Test/UseCases/V1/SearchAddressUseCaseTest.cs
+++ b/LBHAddressesAPITest/Test/UseCases/V1/SearchAddressUseCaseTest.cs
@@ -27,19 +27,7 @@ namespace LBHAddressesAPITest
 
             _classUnderTest = new SearchAddressUseCase(_fakeGateway.Object);
         }
-
-        [Fact]
-        public async Task GivenInvalidInput_WhenExecuteAsync_ThenReturnError()
-        {
-            var request = new SearchAddressRequest
-            {                
-                Gazetteer = LBHAddressesAPI.Helpers.GlobalConstants.Gazetteer.Local
-            };
-            var exception = await Assert.ThrowsAsync<BadRequestException>(async () => await _classUnderTest.ExecuteAsync(request, CancellationToken.None));
-            Assert.Equal("No filter parameters have been provided", exception.ValidationResponse.ValidationErrors.FirstOrDefault().Message);
-        }
-
-
+                
         [Fact]
         public async Task GivenLocalGazetteer_WhenExecuteAsync_ThenOnlyLocalAddressesShouldBeReturned()
         {

--- a/LBHAddressesAPITest/Validation/SearchAddressValidatorTests.cs
+++ b/LBHAddressesAPITest/Validation/SearchAddressValidatorTests.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using FluentAssertions;
+using NUnit.Framework;
+using Moq;
+using LBHAddressesAPI.UseCases.V1.Search.Models;
+using LBHAddressesAPI.Validation;
+
+namespace LBHAddressesAPITest.Validation
+{
+    [TestFixture]
+    public class SearchAddressValidatorTests
+    {
+        private ISearchAddressValidator _classUnderTest;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _classUnderTest = new SearchAddressValidator();
+        }
+    }
+}

--- a/LBHAddressesAPITest/Validation/SearchAddressValidatorTests.cs
+++ b/LBHAddressesAPITest/Validation/SearchAddressValidatorTests.cs
@@ -6,18 +6,47 @@ using NUnit.Framework;
 using Moq;
 using LBHAddressesAPI.UseCases.V1.Search.Models;
 using LBHAddressesAPI.Validation;
+using FluentValidation;
+using FluentValidation.TestHelper;
 
 namespace LBHAddressesAPITest.Validation
 {
     [TestFixture]
     public class SearchAddressValidatorTests
     {
-        private ISearchAddressValidator _classUnderTest;
+        private SearchAddressValidator _classUnderTest;
 
         [SetUp]
         public void SetUp()
         {
             _classUnderTest = new SearchAddressValidator();
+        }
+
+        [TestCase("cat")]
+        [TestCase("provizional")]
+        [TestCase("alternative,hystorical")]
+        public void GivenAnAddressStatusValueThatDoesntMachAllowedOnes_WhenCallingValidation_ItReturnsAnError(string addressStatusVal)
+        {
+            var request = new SearchAddressRequest() { AddressStatus = addressStatusVal };
+            _classUnderTest.ShouldHaveValidationErrorFor(x => x.AddressStatus, request).WithErrorMessage("Value for the parameter is not valid.");
+        }
+
+        [TestCase("alternative")]
+        [TestCase("historical")]
+        [TestCase("approved preffered,historical")]
+        public void GivenAnAllowedAddressStatusValue_WhenCallingValidation_ItReturnsNoErrors(string addressStatusVal)
+        {
+            var request = new SearchAddressRequest() { AddressStatus = addressStatusVal };
+            _classUnderTest.ShouldNotHaveValidationErrorFor(x => x.AddressStatus, request);
+        }
+
+        [TestCase(" ")]
+        [TestCase("")]
+        [TestCase(null)]
+        public void GivenAWhitespaceOrEmptyAddressStatusValue_WhenCallingValidation_ItReturnsAnError(string addressStatusVal)
+        {
+            var request = new SearchAddressRequest() { AddressStatus = addressStatusVal };
+            _classUnderTest.ShouldHaveValidationErrorFor(x => x.AddressStatus, request).WithErrorMessage("Address Status should not be null or empty.");
         }
     }
 }

--- a/LBHAddressesAPITest/Validation/SearchAddressValidatorTests.cs
+++ b/LBHAddressesAPITest/Validation/SearchAddressValidatorTests.cs
@@ -52,6 +52,95 @@ namespace LBHAddressesAPITest.Validation
             _classUnderTest.ShouldHaveValidationErrorFor(x => x.AddressStatus, request);
         }
 
+        [TestCase("CR1 3ED")]
+        [TestCase("NE7")]
+        public void GivenAPostCodeValueInUpperCase_WhenCallingValidation_ItReturnsNoErrors(string postCode)
+        {
+            var request = new SearchAddressRequest() { PostCode = postCode };
+            _classUnderTest.ShouldNotHaveValidationErrorFor(x => x.PostCode, request);
+        }
+
+        [TestCase("w2 5jq")]
+        [TestCase("ne7")]
+        public void GivenAPostCodeValueInLowerCase_WhenCallingValidation_ItReturnsNoErrors(string postCode)
+        {
+            var request = new SearchAddressRequest() { PostCode = postCode };
+            _classUnderTest.ShouldNotHaveValidationErrorFor(x => x.PostCode, request);
+        }
+
+        [TestCase("w2 5JQ")]
+        [TestCase("E11 5ra")]
+        public void GivenAPostCodeValueInLowerCaseAndUpperCase_WhenCallingValidation_ItReturnsNoErrors(string postCode)
+        {
+            var request = new SearchAddressRequest() { PostCode = postCode };
+            _classUnderTest.ShouldNotHaveValidationErrorFor(x => x.PostCode, request);
+        }
+
+        [TestCase("CR13ED")]
+        [TestCase("RE15AD")]
+        public void GivenPostCodeValueWithoutSpaces_WhenCallingValidation_ItReturnsNoErrors(string postCode)
+        {
+            var request = new SearchAddressRequest() { PostCode = postCode };
+            _classUnderTest.ShouldNotHaveValidationErrorFor(x => x.PostCode, request);
+        }
+
+        [TestCase("NW")]
+        [TestCase("E")]
+        public void GivenOnlyAnAreaPartOfThePostCode_WhenCallingValidation_ItReturnsAnError(string postCode)
+        {
+            var request = new SearchAddressRequest() { PostCode = postCode };
+            _classUnderTest.ShouldHaveValidationErrorFor(x => x.PostCode, request).WithErrorMessage("Must provide at least the first part of the postcode.");
+        }
+
+        [TestCase("17 9LL")]
+        [TestCase("8 1LA")]
+        public void GivenOnlyAnIncodeAndADistrictPartsOfThePostCode_WhenCallingValidation_ItReturnsAnError(string postCode)
+        {
+            var request = new SearchAddressRequest() { PostCode = postCode };
+            _classUnderTest.ShouldHaveValidationErrorFor(x => x.PostCode, request).WithErrorMessage("Must provide at least the first part of the postcode.");
+        }
+
+        [TestCase("NW 9LL")]
+        [TestCase("NR1LW")]
+        public void GivenOnlyAnIncodeAndAnAreaPartsOfThePostCode_WhenCallingValidation_ItReturnsAnError(string postCode)
+        {
+            var request = new SearchAddressRequest() { PostCode = postCode };
+            _classUnderTest.ShouldHaveValidationErrorFor(x => x.PostCode, request).WithErrorMessage("Must provide at least the first part of the postcode.");
+        }
+
+        [TestCase("1LL")]
+        [TestCase(" 6BQ")]
+        public void GivenOnlyAnIncodePartOfThePostCode_WhenCallingValidation_ItReturnsAnError(string postCode)
+        {
+            var request = new SearchAddressRequest() { PostCode = postCode };
+            _classUnderTest.ShouldHaveValidationErrorFor(x => x.PostCode, request).WithErrorMessage("Must provide at least the first part of the postcode.");
+        }
+
+        [TestCase("NW9")]
+        [TestCase("RH5 ")]
+        public void GivenOnlyAnOutcodePartOfPostCode_WhenCallingValidation_ItReturnsNoErrors(string postCode)
+        {
+            var request = new SearchAddressRequest() { PostCode = postCode };
+            _classUnderTest.ShouldNotHaveValidationErrorFor(x => x.PostCode, request);
+        }
+
+        [TestCase("E8 1LL")]
+        [TestCase("SW17 1JK")]
+        public void GivenBothPartsOfPostCode_WhenCallingValidation_ItReturnsNoErrors(string postCode)
+        {
+            var request = new SearchAddressRequest() { PostCode = postCode };
+            _classUnderTest.ShouldNotHaveValidationErrorFor(x => x.PostCode, request);
+        }
+
+        [TestCase(" ")]
+        [TestCase("")]
+        [TestCase(null)]
+        public void GivenAWhitespaceOrEmptyPostCodeValue_WhenCallingValidation_ItReturnsAnError(string postCode)
+        {
+            var request = new SearchAddressRequest() { PostCode = postCode };
+            _classUnderTest.ShouldHaveValidationErrorFor(x => x.PostCode, request);
+        }
+
         [Test]
         public void GivenThereIsNoEnvironmentVariableForAddressStatus_WhenValidationIsInvoked_TheErrorIsReturned()
         {

--- a/LBHAddressesAPITest/Validation/SearchAddressValidatorTests.cs
+++ b/LBHAddressesAPITest/Validation/SearchAddressValidatorTests.cs
@@ -24,6 +24,7 @@ namespace LBHAddressesAPITest.Validation
             _classUnderTest = new SearchAddressValidator();
         }
 
+        #region Address status validation
         [TestCase("cat")]
         [TestCase("provizional")]
         [TestCase("alternative,hystorical")]
@@ -51,7 +52,8 @@ namespace LBHAddressesAPITest.Validation
             var request = new SearchAddressRequest() { AddressStatus = addressStatusVal };
             _classUnderTest.ShouldHaveValidationErrorFor(x => x.AddressStatus, request);
         }
-
+        #endregion
+        #region Postcode validation
         [TestCase("CR1 3ED")]
         [TestCase("NE7")]
         public void GivenAPostCodeValueInUpperCase_WhenCallingValidation_ItReturnsNoErrors(string postCode)
@@ -132,15 +134,55 @@ namespace LBHAddressesAPITest.Validation
             _classUnderTest.ShouldNotHaveValidationErrorFor(x => x.PostCode, request);
         }
 
-        [TestCase(" ")]
-        [TestCase("")]
-        [TestCase(null)]
-        public void GivenAWhitespaceOrEmptyPostCodeValue_WhenCallingValidation_ItReturnsAnError(string postCode)
+        #endregion
+
+        #region Request object validation
+                
+        [Test]
+        public void GivenARequestWithJustUPRN_WhenCallingValidation_ItReturnsNoErrors()
         {
-            var request = new SearchAddressRequest() { PostCode = postCode };
-            _classUnderTest.ShouldHaveValidationErrorFor(x => x.PostCode, request);
+            var request = new SearchAddressRequest() { UPRN=12345  };
+            _classUnderTest.ShouldNotHaveValidationErrorFor(x => x.UPRN,request);
         }
 
+        [Test]
+        public void GivenARequestWithOnlyAUPRN_WhenCallingValidation_ItReturnsNoError()
+        {
+            var request = new SearchAddressRequest() { UPRN = 12345 };
+            _classUnderTest.TestValidate(request).ShouldNotHaveError();
+        }
+
+        [Test]
+        public void GivenARequestWithOnlyAUSRN_WhenCallingValidation_ItReturnsNoError()
+        {
+            var request = new SearchAddressRequest() { USRN = 12345 };
+            _classUnderTest.TestValidate(request).ShouldNotHaveError();
+        }
+
+        [Test]
+        public void GivenARequestWithOnlyAPostCode_WhenCallingValidation_ItReturnsNoError()
+        {
+            var request = new SearchAddressRequest() { PostCode = "SW1A 1AA" };
+            _classUnderTest.TestValidate(request).ShouldNotHaveError();
+        }
+
+        [Test]
+        public void GivenARequestWithOnlyAStreet_WhenCallingValidation_ItReturnsNoError()
+        {
+            var request = new SearchAddressRequest() { Street = "Sesame street" };
+            _classUnderTest.TestValidate(request).ShouldNotHaveError();
+        }
+
+        [Test]
+        public void GivenARequestWithBuildingNumberAndNoMandatoryFields_WhenCallingValidation_ItReturnsAnError()
+        {
+            var request = new SearchAddressRequest() { BuildingNumber = "12345" };
+            _classUnderTest.TestValidate(request).ShouldHaveError().WithErrorMessage("You must provide at least one of (UPRN, USRN, Post code, Street)");
+        }
+
+        #endregion
+
+        //Keep this at the end....
         [Test]
         public void GivenThereIsNoEnvironmentVariableForAddressStatus_WhenValidationIsInvoked_TheErrorIsReturned()
         {

--- a/LBHAddressesAPITest/Validation/SearchAddressValidatorTests.cs
+++ b/LBHAddressesAPITest/Validation/SearchAddressValidatorTests.cs
@@ -46,7 +46,7 @@ namespace LBHAddressesAPITest.Validation
         public void GivenAWhitespaceOrEmptyAddressStatusValue_WhenCallingValidation_ItReturnsAnError(string addressStatusVal)
         {
             var request = new SearchAddressRequest() { AddressStatus = addressStatusVal };
-            _classUnderTest.ShouldHaveValidationErrorFor(x => x.AddressStatus, request).WithErrorMessage("Address Status should not be null or empty.");
+            _classUnderTest.ShouldHaveValidationErrorFor(x => x.AddressStatus, request);
         }
     }
 }

--- a/LBHAddressesAPITest/Validation/SearchAddressValidatorTests.cs
+++ b/LBHAddressesAPITest/Validation/SearchAddressValidatorTests.cs
@@ -53,6 +53,11 @@ namespace LBHAddressesAPITest.Validation
             _classUnderTest.ShouldHaveValidationErrorFor(x => x.AddressStatus, request);
         }
         #endregion
+        // Below explanations all use the postcodes IG11 7QD and E5 3XW 
+        //"Incode" refers to the whole second part of the postcode (i.e. 3XW, 7QD)
+        //"Outcode" refers to the whole first part of the postcode (Letter(s) and number(s) - i.e. IG11, E5)
+        //"Area" refers to the first letter(s) of the postcode (i.e.  IG, E)
+        //"District" refers to first number(s) to appear in the postcode (i.e. 11, 5)
         #region Postcode validation
         [TestCase("CR1 3ED")]
         [TestCase("NE7")]
@@ -135,48 +140,40 @@ namespace LBHAddressesAPITest.Validation
         }
 
         #endregion
-
         #region Request object validation
                 
-        [Test]
-        public void GivenARequestWithJustUPRN_WhenCallingValidation_ItReturnsNoErrors()
+        [TestCase(12345)]
+        public void GivenARequestWithOnlyAUPRN_WhenCallingValidation_ItReturnsNoError(int uprn)
         {
-            var request = new SearchAddressRequest() { UPRN=12345  };
-            _classUnderTest.ShouldNotHaveValidationErrorFor(x => x.UPRN,request);
-        }
-
-        [Test]
-        public void GivenARequestWithOnlyAUPRN_WhenCallingValidation_ItReturnsNoError()
-        {
-            var request = new SearchAddressRequest() { UPRN = 12345 };
+            var request = new SearchAddressRequest() { UPRN = uprn };
             _classUnderTest.TestValidate(request).ShouldNotHaveError();
         }
 
-        [Test]
-        public void GivenARequestWithOnlyAUSRN_WhenCallingValidation_ItReturnsNoError()
+        [TestCase(12345)]
+        public void GivenARequestWithOnlyAUSRN_WhenCallingValidation_ItReturnsNoError(int usrn)
         {
-            var request = new SearchAddressRequest() { USRN = 12345 };
+            var request = new SearchAddressRequest() { USRN = usrn };
             _classUnderTest.TestValidate(request).ShouldNotHaveError();
         }
 
-        [Test]
-        public void GivenARequestWithOnlyAPostCode_WhenCallingValidation_ItReturnsNoError()
+        [TestCase("SW1A 1AA")]
+        public void GivenARequestWithOnlyAPostCode_WhenCallingValidation_ItReturnsNoError(string postcode)
         {
-            var request = new SearchAddressRequest() { PostCode = "SW1A 1AA" };
+            var request = new SearchAddressRequest() { PostCode = postcode };
             _classUnderTest.TestValidate(request).ShouldNotHaveError();
         }
 
-        [Test]
-        public void GivenARequestWithOnlyAStreet_WhenCallingValidation_ItReturnsNoError()
+        [TestCase("Sesame street")]
+        public void GivenARequestWithOnlyAStreet_WhenCallingValidation_ItReturnsNoError(string street)
         {
-            var request = new SearchAddressRequest() { Street = "Sesame street" };
+            var request = new SearchAddressRequest() { Street = street };
             _classUnderTest.TestValidate(request).ShouldNotHaveError();
         }
 
-        [Test]
-        public void GivenARequestWithBuildingNumberAndNoMandatoryFields_WhenCallingValidation_ItReturnsAnError()
+        [TestCase("12345")]
+        public void GivenARequestWithBuildingNumberAndNoMandatoryFields_WhenCallingValidation_ItReturnsAnError(string buildingNumber)
         {
-            var request = new SearchAddressRequest() { BuildingNumber = "12345" };
+            var request = new SearchAddressRequest() { BuildingNumber = buildingNumber };
             _classUnderTest.TestValidate(request).ShouldHaveError().WithErrorMessage("You must provide at least one of (UPRN, USRN, Post code, Street)");
         }
 


### PR DESCRIPTION
Adds validation and validation tests.
Validation was for:
AddressStatus
Gazetteer - removed "National" - validation is taken care of by .Net Core.
PostCode
Stopping filter just by Building number.

Card below still blocked because validation is in multiple places.

Jira card numbers: [APIF-262] 


[APIF-262]: https://hackney.atlassian.net/browse/APIF-262