### PR TITLE
Quick changes

### DIFF
--- a/HackneyAddressesAPI/Controllers/V1/SearchAddressController.cs
+++ b/HackneyAddressesAPI/Controllers/V1/SearchAddressController.cs
@@ -24,11 +24,13 @@ namespace LBHAddressesAPI.Controllers.V1
     public class SearchAddressController : BaseController
     {
         private readonly ISearchAddressUseCase _searchAddressUseCase;
+        private readonly ISearchAddressValidator _searchAddressValidator;
 
 
-        public SearchAddressController(ISearchAddressUseCase searchAddressUseCase)
+        public SearchAddressController(ISearchAddressUseCase searchAddressUseCase, ISearchAddressValidator searchAddressValidator)
         {
             _searchAddressUseCase = searchAddressUseCase;
+            _searchAddressValidator = searchAddressValidator;
         }
 
 
@@ -45,9 +47,7 @@ namespace LBHAddressesAPI.Controllers.V1
         [HttpGet, MapToApiVersion("1")]       
         public async Task<IActionResult> GetAddresses([FromQuery] SearchAddressRequest request)
         {
-            var aa = new SearchAddressValidator();
-
-            var validationResults = aa.Validate(request);
+            var validationResults = _searchAddressValidator.Validate(request);
 
             if (validationResults.IsValid)
             {

--- a/HackneyAddressesAPI/Helpers/QueryBuilder.cs
+++ b/HackneyAddressesAPI/Helpers/QueryBuilder.cs
@@ -235,10 +235,12 @@ namespace LBHAddressesAPI.Helpers
                 // paging so if current page passed in is 1 then we set lower bound to be 0 (0 based index). Otherwise we multiply by the page size
 
                 clause += @" ORDER BY town,
+                                     (CASE WHEN postcode IS NULL THEN 1 ELSE 0 END),
                                      postcode,
                                      street_description, 
                                      (CASE WHEN (paon_start_num IS NULL or paon_start_num = 0) THEN 1 ELSE 0 END), 
-                                     paon_start_num, (CASE WHEN building_number IS NULL THEN 1 ELSE 0 END),
+                                     paon_start_num,
+                                     (CASE WHEN building_number IS NULL THEN 1 ELSE 0 END),
                                      building_number,
                                      (CASE WHEN unit_number IS NULL THEN 1 ELSE 0 END),
                                      unit_number,

--- a/HackneyAddressesAPI/Helpers/QueryBuilder.cs
+++ b/HackneyAddressesAPI/Helpers/QueryBuilder.cs
@@ -88,7 +88,7 @@ namespace LBHAddressesAPI.Helpers
         {
             if (!string.IsNullOrEmpty(request.usagePrimary))
             {
-                if (request.usagePrimary.Replace(" ", "").Contains("ParentShell"))
+                if (request.usagePrimary.ToLower().Replace(" ", "").Contains("parentshell"))
                 {
                     return true;
                 }

--- a/HackneyAddressesAPI/Helpers/QueryBuilder.cs
+++ b/HackneyAddressesAPI/Helpers/QueryBuilder.cs
@@ -86,9 +86,9 @@ namespace LBHAddressesAPI.Helpers
         /// <returns>whether to include parent shells or not</returns>
         private static bool IncludeParentShell(SearchAddressRequest request)
         {
-            if (!string.IsNullOrEmpty(request.PropertyClassPrimary))
+            if (!string.IsNullOrEmpty(request.usagePrimary))
             {
-                if (request.PropertyClassPrimary.Replace(" ", "").Contains("ParentShell"))
+                if (request.usagePrimary.Replace(" ", "").Contains("ParentShell"))
                 {
                     return true;
                 }
@@ -190,12 +190,12 @@ namespace LBHAddressesAPI.Helpers
                 clause += " AND USRN = @usrn ";
             }
 
-            if (!string.IsNullOrEmpty(request.PropertyClassPrimary))
+            if (!string.IsNullOrEmpty(request.usagePrimary))
             {
-                string[] propertyClasses = request.PropertyClassPrimary.ToString().Split(",").Distinct(StringComparer.CurrentCultureIgnoreCase).ToArray();
+                string[] propertyClasses = request.usagePrimary.ToString().Split(",").Distinct(StringComparer.CurrentCultureIgnoreCase).ToArray();
                 if (propertyClasses.Count() == 1)
                 {
-                    dbArgs.Add("@primaryClass", request.PropertyClassPrimary, DbType.AnsiString);
+                    dbArgs.Add("@primaryClass", request.usagePrimary, DbType.AnsiString);
                     clause += " AND USAGE_PRIMARY = @primaryClass ";
                 }
                 else

--- a/HackneyAddressesAPI/Helpers/QueryBuilder.cs
+++ b/HackneyAddressesAPI/Helpers/QueryBuilder.cs
@@ -205,12 +205,12 @@ namespace LBHAddressesAPI.Helpers
                 }
             }
 
-            if (!string.IsNullOrEmpty(request.PropertyClassCode))
+            if (!string.IsNullOrEmpty(request.usageCode))
             {
-                string[] classCodes = request.PropertyClassCode.Split(",").Distinct(StringComparer.CurrentCultureIgnoreCase).ToArray();
+                string[] classCodes = request.usageCode.Split(",").Distinct(StringComparer.CurrentCultureIgnoreCase).ToArray();
                 if (classCodes.Count() == 1)
                 {
-                    dbArgs.Add("@propertyClassCode", request.PropertyClassCode + "%", DbType.AnsiString);
+                    dbArgs.Add("@propertyClassCode", request.usageCode + "%", DbType.AnsiString);
                     clause += " AND BLPU_CLASS LIKE @propertyClassCode ";
                 }
                 else

--- a/HackneyAddressesAPI/Infrastructure/V1/Services/ConfigureServices.cs
+++ b/HackneyAddressesAPI/Infrastructure/V1/Services/ConfigureServices.cs
@@ -1,4 +1,5 @@
 ﻿using LBHAddressesAPI.Infrastructure.V1.Logging;
+using LBHAddressesAPI.Validation;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -17,6 +18,7 @@ namespace LBHAddressesAPI.Infrastructure.V1.Services
             services.AddTransient<UseCases.V1.Addresses.ISearchAddressUseCase, UseCases.V1.Addresses.SearchAddressUseCase>();
             services.AddTransient<UseCases.V1.Addresses.IGetAddressCrossReferenceUseCase, UseCases.V1.Addresses.GetAddressCrossReferenceUseCase>();
             services.AddTransient<Gateways.V1.IAddressesGateway>(s => new Gateways.V1.AddressesGateway(connectionString));
+            services.AddTransient<ISearchAddressValidator>(s => new SearchAddressValidator());
         }
     }
 }

--- a/HackneyAddressesAPI/UseCases/V1/Search/Models/SearchAddressRequest.cs
+++ b/HackneyAddressesAPI/UseCases/V1/Search/Models/SearchAddressRequest.cs
@@ -73,7 +73,7 @@ namespace LBHAddressesAPI.UseCases.V1.Search.Models
         /// <summary>
         /// Identifies land and property usage according to this system of classification: https://www.geoplace.co.uk/documents/10181/38204/Appendix+C+-+Classifications/ ; this is a textual description
         /// </summary>
-        public string PropertyClassCode { get; set; }
+        public string usageCode { get; set; }
 
         /// <summary>
         /// Allows a switch between simple and detailed address

--- a/HackneyAddressesAPI/UseCases/V1/Search/Models/SearchAddressRequest.cs
+++ b/HackneyAddressesAPI/UseCases/V1/Search/Models/SearchAddressRequest.cs
@@ -68,7 +68,7 @@ namespace LBHAddressesAPI.UseCases.V1.Search.Models
         /// Unclassified
         /// ALL (default) 
         /// </summary>
-        public string PropertyClassPrimary  { get; set; }
+        public string usagePrimary  { get; set; }
 
         /// <summary>
         /// Identifies land and property usage according to this system of classification: https://www.geoplace.co.uk/documents/10181/38204/Appendix+C+-+Classifications/ ; this is a textual description

--- a/HackneyAddressesAPI/UseCases/V1/Search/Models/SearchAddressRequestValidator.cs
+++ b/HackneyAddressesAPI/UseCases/V1/Search/Models/SearchAddressRequestValidator.cs
@@ -7,7 +7,7 @@ namespace LBHAddressesAPI.UseCases.V1.Search.Models
         public SearchAddressRequestValidator()
         {
             RuleFor(x => x).NotNull();
-            RuleFor(x => x.PageSize).LessThan(50).WithMessage("PageSize cannot exceed 50");
+            RuleFor(x => x.PageSize).LessThan(51).WithMessage("PageSize cannot exceed 50");
             //RuleFor(x => x.addressID).NotNull().NotEmpty().WithMessage("addressID must be provided");
             //RuleFor(x => x.addressID).Length(14).WithMessage("addressID must be 14 characters");
 

--- a/HackneyAddressesAPI/Validation/ISearchAddressValidator.cs
+++ b/HackneyAddressesAPI/Validation/ISearchAddressValidator.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using FluentValidation.Results;
+using LBHAddressesAPI.UseCases.V1.Search.Models;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -7,5 +9,6 @@ namespace LBHAddressesAPI.Validation
 {
     public interface ISearchAddressValidator
     {
+        ValidationResult Validate(SearchAddressRequest instance);
     }
 }

--- a/HackneyAddressesAPI/Validation/SearchAddressValidator.cs
+++ b/HackneyAddressesAPI/Validation/SearchAddressValidator.cs
@@ -21,7 +21,7 @@ namespace LBHAddressesAPI.Validation
             RuleFor(r => r.AddressStatus).NotNull().NotEmpty();
             RuleFor(r => r.AddressStatus).Must(CanBeAnyCombinationOfAllowedValues).WithMessage("Value for the parameter is not valid.");
 
-            RuleFor(r => r.PostCode).Matches(new Regex("^((([A-Za-z][0-9]{1,2})|(([A-Za-z][A-Ha-hJ-Yj-y][0-9]{1,2})|(([A-Za-z][0-9][A-Za-z])|([A-Za-z][A-Ha-hJ-Yj-y][0-9][A-Za-z]))))( )?(([0-9][A-Za-z]{2})?|([0-9][A-Za-z])?|([0-9])?))$")).WithMessage("Must provide at least the first part of the postcode.");
+            RuleFor(r => r.PostCode).Matches(new Regex("^((([A-Za-z][0-9]{1,2})|(([A-Za-z][A-Ha-hJ-Yj-y][0-9]{1,2})|(([A-Za-z][0-9][A-Za-z])|([A-Za-z][A-Ha-hJ-Yj-y][0-9][A-Za-z]))))( )?(([0-9][A-Za-z]?[A-Za-z]?)?))$")).WithMessage("Must provide at least the first part of the postcode.");
 
             RuleFor(r => r).Must(CheckForAtLeastOneMandatoryFilterProperty).WithMessage("You must provide at least one of (UPRN, USRN, Post code, Street)");
 

--- a/HackneyAddressesAPI/Validation/SearchAddressValidator.cs
+++ b/HackneyAddressesAPI/Validation/SearchAddressValidator.cs
@@ -23,13 +23,13 @@ namespace LBHAddressesAPI.Validation
 
             RuleFor(r => r.PostCode).Matches(new Regex("^((([A-Za-z][0-9]{1,2})|(([A-Za-z][A-Ha-hJ-Yj-y][0-9]{1,2})|(([A-Za-z][0-9][A-Za-z])|([A-Za-z][A-Ha-hJ-Yj-y][0-9][A-Za-z]))))( )?(([0-9][A-Za-z]?[A-Za-z]?)?))$")).WithMessage("Must provide at least the first part of the postcode.");
 
-            RuleFor(r => r).Must(CheckForAtLeastOneMandatoryFilterProperty).WithMessage("You must provide at least one of (UPRN, USRN, Post code, Street)");
+            RuleFor(r => r).Must(CheckForAtLeastOneMandatoryFilterProperty).WithMessage("You must provide at least one of (uprn, usrn, postcode, street, usagePrimary, usageCode).");
 
         }
 
         private bool CheckForAtLeastOneMandatoryFilterProperty(SearchAddressRequest request)
         {
-            if (request.UPRN == null && request.USRN == null && request.PostCode == null && request.Street == null)
+            if (request.UPRN == null && request.USRN == null && request.PostCode == null && request.Street == null && request.usagePrimary == null && request.usageCode == null)
             {
                 return false;
             }

--- a/HackneyAddressesAPI/Validation/SearchAddressValidator.cs
+++ b/HackneyAddressesAPI/Validation/SearchAddressValidator.cs
@@ -21,7 +21,7 @@ namespace LBHAddressesAPI.Validation
             RuleFor(r => r.AddressStatus).NotNull().NotEmpty();
             RuleFor(r => r.AddressStatus).Must(CanBeAnyCombinationOfAllowedValues).WithMessage("Value for the parameter is not valid.");
 
-            RuleFor(r => r.PostCode).Matches(new Regex("^((([A-Za-z][0-9]{1,2})|(([A-Za-z][A-Ha-hJ-Yj-y][0-9]{1,2})|(([A-Za-z][0-9][A-Za-z])|([A-Za-z][A-Ha-hJ-Yj-y][0-9][A-Za-z]))))( )?([0-9][A-Za-z]{2})?)$")).WithMessage("Must provide at least the first part of the postcode.");
+            RuleFor(r => r.PostCode).Matches(new Regex("^((([A-Za-z][0-9]{1,2})|(([A-Za-z][A-Ha-hJ-Yj-y][0-9]{1,2})|(([A-Za-z][0-9][A-Za-z])|([A-Za-z][A-Ha-hJ-Yj-y][0-9][A-Za-z]))))( )?(([0-9][A-Za-z]{2})?|([0-9][A-Za-z])?|([0-9])?))$")).WithMessage("Must provide at least the first part of the postcode.");
 
             RuleFor(r => r).Must(CheckForAtLeastOneMandatoryFilterProperty).WithMessage("You must provide at least one of (UPRN, USRN, Post code, Street)");
 

--- a/LBHAddressesAPITest/Test/Controllers/V1/SearchAddressControllerTests.cs
+++ b/LBHAddressesAPITest/Test/Controllers/V1/SearchAddressControllerTests.cs
@@ -13,6 +13,7 @@ using Microsoft.AspNetCore.Mvc;
 using LBHAddressesAPI.Models;
 using LBHAddressesAPI.Infrastructure.V1.API;
 using LBHAddressesAPI.Helpers;
+using LBHAddressesAPI.Validation;
 
 namespace LBHAddressesAPITest.Test.Controllers.V1
 {
@@ -20,12 +21,14 @@ namespace LBHAddressesAPITest.Test.Controllers.V1
     {
         private SearchAddressController _classUnderTest;
         private Mock<ISearchAddressUseCase> _mock;
+        private SearchAddressValidator _validator;
 
         public SearchAddressControllerTests()
         {
             Environment.SetEnvironmentVariable("ALLOWED_ADDRESSSTATUS_VALUES", "historical;alternative;approved preferred;provisional");
             _mock = new Mock<ISearchAddressUseCase>();
-            _classUnderTest = new SearchAddressController(_mock.Object);
+            _validator = new SearchAddressValidator();
+            _classUnderTest = new SearchAddressController(_mock.Object, _validator);
         }
 
 

--- a/LBHAddressesAPITest/Test/Helpers/QueryBuilderTest.cs
+++ b/LBHAddressesAPITest/Test/Helpers/QueryBuilderTest.cs
@@ -49,7 +49,7 @@ namespace LBHAddressesAPITest.Test.Helpers
             {
                 Format = GlobalConstants.Format.Simple,
                 PostCode = "RM12PR",
-                PropertyClassPrimary = "ParentShell"
+                usagePrimary = "ParentShell"
             };
 
             string response = QueryBuilder.GetSearchAddressQuery(request, true, true, false, ref dbArgs);

--- a/LBHAddressesAPITest/Validation/SearchAddressValidatorTests.cs
+++ b/LBHAddressesAPITest/Validation/SearchAddressValidatorTests.cs
@@ -54,10 +54,12 @@ namespace LBHAddressesAPITest.Validation
         }
         #endregion
         // Below explanations all use the postcodes IG11 7QD and E5 3XW 
-        //"Incode" refers to the whole second part of the postcode (i.e. 3XW, 7QD)
-        //"Outcode" refers to the whole first part of the postcode (Letter(s) and number(s) - i.e. IG11, E5)
-        //"Area" refers to the first letter(s) of the postcode (i.e.  IG, E)
-        //"District" refers to first number(s) to appear in the postcode (i.e. 11, 5)
+        //"Incode" refers to the whole second part of the postcode (i.e. 3XW, 7QD) from (E11 3XW, W3 7QD)
+        //"Outcode" refers to the whole first part of the postcode (Letter(s) and number(s) - i.e. IG11, E5) from (IG11 9LL, E5 2LL)
+        //"Area" refers to the first letter(s) of the postcode (i.e.  IG, E) from (IG11 9LL, E5 2LL)
+        //"District" refers to first number(s) to appear in the postcode (i.e. 11, 5) from (IG11 9LL, E5 2LL)
+        //"Sector" refers to the number in the second part of the postcode (i.e. 9, 7) from (SW2 9DN, NE4 7JU)
+        //"Unit" refers to the letters in the second part of the postcode (i.e. DN, JU) from (SW2 9DN, NE4 7JU)
         #region Postcode validation
         [TestCase("CR1 3ED")]
         [TestCase("NE7")]
@@ -78,6 +80,14 @@ namespace LBHAddressesAPITest.Validation
         [TestCase("w2 5JQ")]
         [TestCase("E11 5ra")]
         public void GivenAPostCodeValueInLowerCaseAndUpperCase_WhenCallingValidation_ItReturnsNoErrors(string postCode)
+        {
+            var request = new SearchAddressRequest() { PostCode = postCode };
+            _classUnderTest.ShouldNotHaveValidationErrorFor(x => x.PostCode, request);
+        }
+
+        [TestCase("w2 ")]
+        [TestCase("E11 ")]
+        public void GivenAnOutcodeWithSpace_WhenCallingValidation_ItReturnsNoErrors(string postCode)
         {
             var request = new SearchAddressRequest() { PostCode = postCode };
             _classUnderTest.ShouldNotHaveValidationErrorFor(x => x.PostCode, request);
@@ -123,8 +133,18 @@ namespace LBHAddressesAPITest.Validation
             _classUnderTest.ShouldHaveValidationErrorFor(x => x.PostCode, request).WithErrorMessage("Must provide at least the first part of the postcode.");
         }
 
-        [TestCase("NW9")]
-        [TestCase("RH5 ")]
+        [TestCase("E9")] //A9
+        [TestCase("S5")]
+        [TestCase("S11")] //A99
+        [TestCase("W12")]
+        [TestCase("NW9")] //AA9
+        [TestCase("RH5")]
+        [TestCase("SW17")] // AA99
+        [TestCase("NE17")]
+        [TestCase("W4R")] // A9A
+        [TestCase("N1C")]
+        [TestCase("NW1W")] // AA9A
+        [TestCase("CR1H")]
         public void GivenOnlyAnOutcodePartOfPostCode_WhenCallingValidation_ItReturnsNoErrors(string postCode)
         {
             var request = new SearchAddressRequest() { PostCode = postCode };
@@ -150,6 +170,38 @@ namespace LBHAddressesAPITest.Validation
         [TestCase("EEE")]
         [TestCase("THE")]
         public void GivenThreeCharacters_WhenCallingValidation_ItReturnsAnError(string postCode)
+        {
+            var request = new SearchAddressRequest() { PostCode = postCode };
+            _classUnderTest.ShouldHaveValidationErrorFor(x => x.PostCode, request).WithErrorMessage("Must provide at least the first part of the postcode.");
+        }
+
+        [TestCase("SW11 9")]
+        [TestCase("e14 2")]
+        public void GivenAnOutcodeAndASector_WhenCallingValidation_ItReturnsNoErrors(string postCode)
+        {
+            var request = new SearchAddressRequest() { PostCode = postCode };
+            _classUnderTest.ShouldNotHaveValidationErrorFor(x => x.PostCode, request);
+        }
+
+        [TestCase("SW7 9A")]
+        [TestCase("n12 8F")]
+        public void GivenAnOutcodeAndASectorAndTheFirstLetterOfTheUnit_WhenCallingValidation_ItReturnsNoErrors(string postCode)
+        {
+            var request = new SearchAddressRequest() { PostCode = postCode };
+            _classUnderTest.ShouldNotHaveValidationErrorFor(x => x.PostCode, request);
+        }
+
+        [TestCase("N8 LL")]
+        [TestCase("NW11 AE")]
+        public void GivenAnOutcodeAndAUnit_WhenCallingValidation_ItReturnsAnError(string postCode)
+        {
+            var request = new SearchAddressRequest() { PostCode = postCode };
+            _classUnderTest.ShouldHaveValidationErrorFor(x => x.PostCode, request).WithErrorMessage("Must provide at least the first part of the postcode.");
+        }
+
+        [TestCase("S10 H")]
+        [TestCase("W1 J")]
+        public void GivenAnOutcodeAndOnlyOneLetterOfAUnit_WhenCallingValidation_ItReturnsAnError(string postCode)
         {
             var request = new SearchAddressRequest() { PostCode = postCode };
             _classUnderTest.ShouldHaveValidationErrorFor(x => x.PostCode, request).WithErrorMessage("Must provide at least the first part of the postcode.");

--- a/LBHAddressesAPITest/Validation/SearchAddressValidatorTests.cs
+++ b/LBHAddressesAPITest/Validation/SearchAddressValidatorTests.cs
@@ -238,11 +238,25 @@ namespace LBHAddressesAPITest.Validation
             _classUnderTest.TestValidate(request).ShouldNotHaveError();
         }
 
+        [TestCase("someValue")]
+        public void GivenARequestWithOnlyUsagePrimary_WhenCallingValidation_ItReturnsNoError(string UsagePrimary)
+        {
+            var request = new SearchAddressRequest() { usagePrimary = UsagePrimary };
+            _classUnderTest.TestValidate(request).ShouldNotHaveError();
+        }
+
+        [TestCase("otherValue")]
+        public void GivenARequestWithOnlyUsageCode_WhenCallingValidation_ItReturnsNoError(string UsageCode)
+        {
+            var request = new SearchAddressRequest() { usageCode = UsageCode };
+            _classUnderTest.TestValidate(request).ShouldNotHaveError();
+        }
+
         [TestCase("12345")]
         public void GivenARequestWithBuildingNumberAndNoMandatoryFields_WhenCallingValidation_ItReturnsAnError(string buildingNumber)
         {
             var request = new SearchAddressRequest() { BuildingNumber = buildingNumber };
-            _classUnderTest.TestValidate(request).ShouldHaveError().WithErrorMessage("You must provide at least one of (UPRN, USRN, Post code, Street)");
+            _classUnderTest.TestValidate(request).ShouldHaveError().WithErrorMessage("You must provide at least one of (uprn, usrn, postcode, street, usagePrimary, usageCode).");
         }
 
         #endregion


### PR DESCRIPTION
What:
- A change to part of SQL query responsible for ordering.
- A change to Regex expression validating for postcodes. It used to accept only the Outcode (SW18) and the Full Postcode (SW18 8HJ). Now in addition to that, it accepts Outcode + Sector (SW18 8), Outcode + Sector + First Letter of Unit (SW18 8H).
- Changed the variable naming of 'PropertyClassPrimary' to 'usagePrimary'.
- Changed the variable naming of 'PropertyClassCode' to 'usageCode'.
- Added new validation class to request pipeline through dependency injection.
- Added two more parameters to the 'at least 1 mandatory' validation (usageCode, usagePrimary).
- Fixed the paging error bug.
- Fixed the odd behaviour when 'Parent Shell' value for usagePrimary is provided.


Notes:
- Jira Tickets: [APIF-261], [APIF-257], [APIF-271], [APIF-270], [APIF-265], [APIF-272], [APIF-273], [APIF-274]


[APIF-261]: https://hackney.atlassian.net/browse/APIF-261
[APIF-257]: https://hackney.atlassian.net/browse/APIF-257
[APIF-271]: https://hackney.atlassian.net/browse/APIF-271
[APIF-270]: https://hackney.atlassian.net/browse/APIF-270
[APIF-265]: https://hackney.atlassian.net/browse/APIF-265
[APIF-272]: https://hackney.atlassian.net/browse/APIF-272
[APIF-273]: https://hackney.atlassian.net/browse/APIF-273
[APIF-274]: https://hackney.atlassian.net/browse/APIF-274