### PR TITLE
More fixes

### DIFF
--- a/HackneyAddressesAPI/UseCases/V1/Search/Models/SearchAddressRequest.cs
+++ b/HackneyAddressesAPI/UseCases/V1/Search/Models/SearchAddressRequest.cs
@@ -18,6 +18,7 @@ namespace LBHAddressesAPI.UseCases.V1.Search.Models
         public SearchAddressRequest()
         {
             this.AddressStatus = "approved preferred";
+            this.Gazetteer = GlobalConstants.Gazetteer.Both;
         }
 
         //    [FromQuery]string PropertyClassCode = null/*,

--- a/HackneyAddressesAPI/Validation/SearchAddressValidator.cs
+++ b/HackneyAddressesAPI/Validation/SearchAddressValidator.cs
@@ -7,6 +7,7 @@ using LBHAddressesAPI.UseCases.V1.Search.Models;
 using LBHAddressesAPI.Exceptions;
 using System.Text.RegularExpressions;
 using LBHAddressesAPI.Infrastructure.V1.Validation;
+using LBHAddressesAPI.Helpers;
 
 namespace LBHAddressesAPI.Validation
 {
@@ -24,7 +25,8 @@ namespace LBHAddressesAPI.Validation
 
             RuleFor(r => r.PostCode).Matches(new Regex("^((([A-Za-z][0-9]{1,2})|(([A-Za-z][A-Ha-hJ-Yj-y][0-9]{1,2})|(([A-Za-z][0-9][A-Za-z])|([A-Za-z][A-Ha-hJ-Yj-y][0-9][A-Za-z]))))( )?(([0-9][A-Za-z]?[A-Za-z]?)?))$")).WithMessage("Must provide at least the first part of the postcode.");
 
-            RuleFor(r => r).Must(CheckForAtLeastOneMandatoryFilterProperty).WithMessage("You must provide at least one of (uprn, usrn, postcode, street, usagePrimary, usageCode).");
+            RuleFor(r => r).Must(CheckForAtLeastOneMandatoryFilterPropertyWithGazetteerLocal).WithMessage("You must provide at least one of (uprn, usrn, postcode, street, usagePrimary, usageCode), when gazeteer is 'local'.");
+            RuleFor(r => r).Must(CheckForAtLeastOneMandatoryFilterPropertyWithGazetteerBoth).WithMessage("You must provide at least one of (uprn, usrn, postcode), when gazetteer is 'both'.");
 
             RuleFor(r => r.RequestFields).Must(CheckForInvalidProperties).WithMessage("Invalid properties have been provided.");
         }
@@ -50,9 +52,19 @@ namespace LBHAddressesAPI.Validation
             }
         }
 
-        private bool CheckForAtLeastOneMandatoryFilterProperty(SearchAddressRequest request)
+        private bool CheckForAtLeastOneMandatoryFilterPropertyWithGazetteerLocal(SearchAddressRequest request)
         {
-            if (request.UPRN == null && request.USRN == null && request.PostCode == null && request.Street == null && request.usagePrimary == null && request.usageCode == null)
+            if(request.Gazetteer == GlobalConstants.Gazetteer.Local && request.UPRN == null && request.USRN == null && request.PostCode == null && request.Street == null && request.usagePrimary == null && request.usageCode == null)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        private bool CheckForAtLeastOneMandatoryFilterPropertyWithGazetteerBoth(SearchAddressRequest request)
+        {
+            if(request.Gazetteer == GlobalConstants.Gazetteer.Both && request.UPRN == null && request.USRN == null && request.PostCode == null)
             {
                 return false;
             }

--- a/LBHAddressesAPITest/Test/Helpers/QueryBuilderTest.cs
+++ b/LBHAddressesAPITest/Test/Helpers/QueryBuilderTest.cs
@@ -57,22 +57,6 @@ namespace LBHAddressesAPITest.Test.Helpers
         }
 
         [Fact]
-        public async Task GivenValidSearchAddressRequest_WhenCallingQueryBuilderWithNoGazetteer_ThenShouldReturnQueryForLLPG()
-        {
-            var dbArgs = new DynamicParameters();//dynamically add parameters to Dapper query
-            SearchAddressRequest request = new SearchAddressRequest
-            {
-                Format = GlobalConstants.Format.Simple,
-                PostCode = "RM12PR"
-            };
-
-            string response = QueryBuilder.GetSearchAddressQuery(request, true, true, false, ref dbArgs);
-            response.Replace("  ", " ").Should().Contain("AND Gazetteer = @gazetteer".Replace("  ", " "));
-            string gazetteer = dbArgs.Get<dynamic>("gazetteer");
-            gazetteer.Should().Equals("Local");
-        }
-
-        [Fact]
         public async Task GivenValidSearchAddressRequest_WhenCallingQueryBuilderWithisCountQuery_ThenShouldReturnQueryForCount()
         {
             var dbArgs = new DynamicParameters();//dynamically add parameters to Dapper query

--- a/LBHAddressesAPITest/Validation/SearchAddressValidatorTests.cs
+++ b/LBHAddressesAPITest/Validation/SearchAddressValidatorTests.cs
@@ -254,52 +254,101 @@ namespace LBHAddressesAPITest.Validation
         #region Request object validation
 
         [TestCase(12345)]
-        public void GivenARequestWithOnlyAUPRN_WhenCallingValidation_ItReturnsNoError(int uprn)
+        public void GivenARequestWithOnlyUPRN_IfGazetteerIsLocal_WhenCallingValidation_ItReturnsNoError(int uprn)
         {
             var request = new SearchAddressRequest() { UPRN = uprn };
             _classUnderTest.TestValidate(request).ShouldNotHaveError();
         }
 
         [TestCase(12345)]
-        public void GivenARequestWithOnlyAUSRN_WhenCallingValidation_ItReturnsNoError(int usrn)
+        public void GivenARequestWithOnlyUPRN_IfGazetteerIsBoth_WhenCallingValidation_ItReturnsNoError(int uprn)
+        {
+            var request = new SearchAddressRequest() { UPRN = uprn };
+            _classUnderTest.TestValidate(request).ShouldNotHaveError();
+        }
+
+        [TestCase(12345)]
+        public void GivenARequestWithOnlyUSRN_IfGazetteerIsLocal_WhenCallingValidation_ItReturnsNoError(int usrn)
+        {
+            var request = new SearchAddressRequest() { USRN = usrn };
+            _classUnderTest.TestValidate(request).ShouldNotHaveError();
+        }
+
+        [TestCase(12345)]
+        public void GivenARequestWithOnlyUSRN_IfGazetteerIsBoth_WhenCallingValidation_ItReturnsNoError(int usrn)
         {
             var request = new SearchAddressRequest() { USRN = usrn };
             _classUnderTest.TestValidate(request).ShouldNotHaveError();
         }
 
         [TestCase("SW1A 1AA")]
-        public void GivenARequestWithOnlyAPostCode_WhenCallingValidation_ItReturnsNoError(string postcode)
+        public void GivenARequestWithOnlyAPostCode_IfGazetteerIsLocal_WhenCallingValidation_ItReturnsNoError(string postcode)
+        {
+            var request = new SearchAddressRequest() { PostCode = postcode };
+            _classUnderTest.TestValidate(request).ShouldNotHaveError();
+        }
+
+        [TestCase("SW1A 1AA")]
+        public void GivenARequestWithOnlyAPostCode_IfGazetteerIsBoth_WhenCallingValidation_ItReturnsNoError(string postcode)
         {
             var request = new SearchAddressRequest() { PostCode = postcode };
             _classUnderTest.TestValidate(request).ShouldNotHaveError();
         }
 
         [TestCase("Sesame street")]
-        public void GivenARequestWithOnlyAStreet_WhenCallingValidation_ItReturnsNoError(string street)
+        public void GivenARequestWithOnlyAStreet_IfGazetteerIsLocal_WhenCallingValidation_ItReturnsNoError(string street)
         {
             var request = new SearchAddressRequest() { Street = street };
             _classUnderTest.TestValidate(request).ShouldNotHaveError();
         }
 
+        [TestCase("Sesame street")]
+        public void GivenARequestWithOnlyAStreet_IfGazetteerIsBoth_WhenCallingValidation_ItReturnsAnError(string street)
+        {
+            var request = new SearchAddressRequest() { Street = street };
+            _classUnderTest.TestValidate(request).ShouldHaveError().WithErrorMessage("You must provide at least one of (uprn, usrn, postcode), when gazetteer is 'both'.");
+        }
+
         [TestCase("someValue")]
-        public void GivenARequestWithOnlyUsagePrimary_WhenCallingValidation_ItReturnsNoError(string UsagePrimary)
+        public void GivenARequestWithOnlyUsagePrimary_IfGazetteerIsLocal_WhenCallingValidation_ItReturnsNoError(string UsagePrimary)
         {
             var request = new SearchAddressRequest() { usagePrimary = UsagePrimary };
             _classUnderTest.TestValidate(request).ShouldNotHaveError();
         }
 
+        [TestCase("someValue")]
+        public void GivenARequestWithOnlyUsagePrimary_IfGazetteerIsBoth_WhenCallingValidation_ItReturnsAnError(string UsagePrimary)
+        {
+            var request = new SearchAddressRequest() { usagePrimary = UsagePrimary };
+            _classUnderTest.TestValidate(request).ShouldHaveError().WithErrorMessage("You must provide at least one of (uprn, usrn, postcode), when gazetteer is 'both'.");
+        }
+
         [TestCase("otherValue")]
-        public void GivenARequestWithOnlyUsageCode_WhenCallingValidation_ItReturnsNoError(string UsageCode)
+        public void GivenARequestWithOnlyUsageCode_IfGazetteerIsLocal_WhenCallingValidation_ItReturnsNoError(string UsageCode)
         {
             var request = new SearchAddressRequest() { usageCode = UsageCode };
             _classUnderTest.TestValidate(request).ShouldNotHaveError();
         }
 
+        [TestCase("otherValue")]
+        public void GivenARequestWithOnlyUsageCode_IfGazetteerIsBoth_WhenCallingValidation_ItReturnsAnError(string UsageCode)
+        {
+            var request = new SearchAddressRequest() { usageCode = UsageCode };
+            _classUnderTest.TestValidate(request).ShouldHaveError().WithErrorMessage("You must provide at least one of (uprn, usrn, postcode), when gazetteer is 'both'.");
+        }
+
         [TestCase("12345")]
-        public void GivenARequestWithBuildingNumberAndNoMandatoryFields_WhenCallingValidation_ItReturnsAnError(string buildingNumber)
+        public void GivenARequestWithNoMandatoryFields_IfGazetteerIsLocal_WhenCallingValidation_ItReturnsAnError(string buildingNumber)
         {
             var request = new SearchAddressRequest() { BuildingNumber = buildingNumber };
-            _classUnderTest.TestValidate(request).ShouldHaveError().WithErrorMessage("You must provide at least one of (uprn, usrn, postcode, street, usagePrimary, usageCode).");
+            _classUnderTest.TestValidate(request).ShouldHaveError().WithErrorMessage("You must provide at least one of (uprn, usrn, postcode, street, usagePrimary, usageCode), when gazeteer is 'local'.");
+        }
+
+        [TestCase("12345")]
+        public void GivenARequestWithNoMandatoryFields_IfGazetteerIsBoth_WhenCallingValidation_ItReturnsAnError(string buildingNumber)
+        {
+            var request = new SearchAddressRequest() { BuildingNumber = buildingNumber };
+            _classUnderTest.TestValidate(request).ShouldHaveError().WithErrorMessage("You must provide at least one of (uprn, usrn, postcode), when gazetteer is 'both'.");
         }
 
         #endregion

--- a/LBHAddressesAPITest/Validation/SearchAddressValidatorTests.cs
+++ b/LBHAddressesAPITest/Validation/SearchAddressValidatorTests.cs
@@ -9,6 +9,7 @@ using LBHAddressesAPI.Validation;
 using FluentValidation;
 using FluentValidation.TestHelper;
 using LBHAddressesAPI.Exceptions;
+using LBHAddressesAPI.Helpers;
 
 namespace LBHAddressesAPITest.Validation
 {
@@ -256,7 +257,7 @@ namespace LBHAddressesAPITest.Validation
         [TestCase(12345)]
         public void GivenARequestWithOnlyUPRN_IfGazetteerIsLocal_WhenCallingValidation_ItReturnsNoError(int uprn)
         {
-            var request = new SearchAddressRequest() { UPRN = uprn };
+            var request = new SearchAddressRequest() { UPRN = uprn, Gazetteer = GlobalConstants.Gazetteer.Local };
             _classUnderTest.TestValidate(request).ShouldNotHaveError();
         }
 
@@ -270,7 +271,7 @@ namespace LBHAddressesAPITest.Validation
         [TestCase(12345)]
         public void GivenARequestWithOnlyUSRN_IfGazetteerIsLocal_WhenCallingValidation_ItReturnsNoError(int usrn)
         {
-            var request = new SearchAddressRequest() { USRN = usrn };
+            var request = new SearchAddressRequest() { USRN = usrn, Gazetteer = GlobalConstants.Gazetteer.Local };
             _classUnderTest.TestValidate(request).ShouldNotHaveError();
         }
 
@@ -284,7 +285,7 @@ namespace LBHAddressesAPITest.Validation
         [TestCase("SW1A 1AA")]
         public void GivenARequestWithOnlyAPostCode_IfGazetteerIsLocal_WhenCallingValidation_ItReturnsNoError(string postcode)
         {
-            var request = new SearchAddressRequest() { PostCode = postcode };
+            var request = new SearchAddressRequest() { PostCode = postcode, Gazetteer = GlobalConstants.Gazetteer.Local };
             _classUnderTest.TestValidate(request).ShouldNotHaveError();
         }
 
@@ -298,7 +299,7 @@ namespace LBHAddressesAPITest.Validation
         [TestCase("Sesame street")]
         public void GivenARequestWithOnlyAStreet_IfGazetteerIsLocal_WhenCallingValidation_ItReturnsNoError(string street)
         {
-            var request = new SearchAddressRequest() { Street = street };
+            var request = new SearchAddressRequest() { Street = street, Gazetteer = GlobalConstants.Gazetteer.Local };
             _classUnderTest.TestValidate(request).ShouldNotHaveError();
         }
 
@@ -312,7 +313,7 @@ namespace LBHAddressesAPITest.Validation
         [TestCase("someValue")]
         public void GivenARequestWithOnlyUsagePrimary_IfGazetteerIsLocal_WhenCallingValidation_ItReturnsNoError(string UsagePrimary)
         {
-            var request = new SearchAddressRequest() { usagePrimary = UsagePrimary };
+            var request = new SearchAddressRequest() { usagePrimary = UsagePrimary, Gazetteer = GlobalConstants.Gazetteer.Local };
             _classUnderTest.TestValidate(request).ShouldNotHaveError();
         }
 
@@ -326,7 +327,7 @@ namespace LBHAddressesAPITest.Validation
         [TestCase("otherValue")]
         public void GivenARequestWithOnlyUsageCode_IfGazetteerIsLocal_WhenCallingValidation_ItReturnsNoError(string UsageCode)
         {
-            var request = new SearchAddressRequest() { usageCode = UsageCode };
+            var request = new SearchAddressRequest() { usageCode = UsageCode, Gazetteer = GlobalConstants.Gazetteer.Local };
             _classUnderTest.TestValidate(request).ShouldNotHaveError();
         }
 
@@ -340,7 +341,7 @@ namespace LBHAddressesAPITest.Validation
         [TestCase("12345")]
         public void GivenARequestWithNoMandatoryFields_IfGazetteerIsLocal_WhenCallingValidation_ItReturnsAnError(string buildingNumber)
         {
-            var request = new SearchAddressRequest() { BuildingNumber = buildingNumber };
+            var request = new SearchAddressRequest() { BuildingNumber = buildingNumber, Gazetteer = GlobalConstants.Gazetteer.Local };
             _classUnderTest.TestValidate(request).ShouldHaveError().WithErrorMessage("You must provide at least one of (uprn, usrn, postcode, street, usagePrimary, usageCode), when gazeteer is 'local'.");
         }
 


### PR DESCRIPTION
What:
- Set default gazetteer value to 'Both'.
- Removed the obsolete query builder test.
- TDD'ed the validation feature for the gazetteer that allows to search by parameters of different levels of broadness depending on what gazetteer it is.

Why:
- Test was removed because it was checking 2 things that we need to be the opposite of what they are now. For instance, it is checking what happens when gazetteer is passed in empty, however the implementation of SearchAddressRequest makes sure that the default is set upon creation of the object - so it can never really be empty, unless you go out of the way to set empty within the code.
Also it's expecting the see the gazetteer value set to 'Local' in the assertion, however it actually has to be 'Both'. Not to say that we can't have the tests for all this, however I don't believe they should be in querybuilder tests. These would actually need to be SearchAddressRequest tests that check if the default the values are set to what we need them to be. Question is - do we need such tests, if the implementation is just a 1liner in the constructor?

Notes:
- Jira Tickets: [APIF-275], [APIF-276]

[APIF-275]: https://hackney.atlassian.net/browse/APIF-275
[APIF-276]: https://hackney.atlassian.net/browse/APIF-276