### PR TITLE
More gazetteer work

### DIFF
--- a/HackneyAddressesAPI/Helpers/QueryBuilder.cs
+++ b/HackneyAddressesAPI/Helpers/QueryBuilder.cs
@@ -290,10 +290,11 @@ namespace LBHAddressesAPI.Helpers
                 }
             }
 
-            if (request.Gazetteer == GlobalConstants.Gazetteer.Both ? false : true)//Gazetteer
+            if (request.Gazetteer == GlobalConstants.Gazetteer.Local)//Gazetteer
             {
                 dbArgs.Add("@gazetteer", request.Gazetteer.ToString(), DbType.AnsiString);
                 clause += " AND Gazetteer = @gazetteer ";
+                clause += " AND neverexport = 0 ";
             }
 
             if (includePaging)//paging

--- a/HackneyAddressesAPI/Helpers/QueryBuilder.cs
+++ b/HackneyAddressesAPI/Helpers/QueryBuilder.cs
@@ -293,8 +293,14 @@ namespace LBHAddressesAPI.Helpers
             if (request.Gazetteer == GlobalConstants.Gazetteer.Local)//Gazetteer
             {
                 dbArgs.Add("@gazetteer", request.Gazetteer.ToString(), DbType.AnsiString);
+                dbArgs.Add("@neverexport", request.HackneyGazetteerOutOfBoroughAddress, DbType.Boolean);
                 clause += " AND Gazetteer = @gazetteer ";
-                clause += " AND neverexport = 0 ";
+                clause += " AND neverexport = @neverexport ";
+            }
+            else if(request.Gazetteer == GlobalConstants.Gazetteer.Both && request.HackneyGazetteerOutOfBoroughAddress != null)
+            {
+                dbArgs.Add("@neverexport", request.HackneyGazetteerOutOfBoroughAddress, DbType.Boolean);
+                clause += " AND neverexport = @neverexport ";
             }
 
             if (includePaging)//paging

--- a/HackneyAddressesAPI/UseCases/V1/Search/Models/SearchAddressRequest.cs
+++ b/HackneyAddressesAPI/UseCases/V1/Search/Models/SearchAddressRequest.cs
@@ -14,6 +14,7 @@ namespace LBHAddressesAPI.UseCases.V1.Search.Models
     /// </summary>
     public class SearchAddressRequest : IRequest, IPagedRequest
     {
+        private GlobalConstants.Gazetteer _gazetteer;
 
         public SearchAddressRequest()
         {
@@ -44,7 +45,23 @@ namespace LBHAddressesAPI.UseCases.V1.Search.Models
         /// <summary>
         /// LOCAL/NATIONAL/BOTH (Defaults to LOCAL)
         /// </summary>
-        public GlobalConstants.Gazetteer Gazetteer { get; set; }
+        public GlobalConstants.Gazetteer Gazetteer
+        {
+            get { return _gazetteer; }
+            set
+            {
+                _gazetteer = value;
+
+                if (_gazetteer == GlobalConstants.Gazetteer.Local)
+                {
+                    HackneyGazetteerOutOfBoroughAddress = false;
+                }
+                else if (_gazetteer == GlobalConstants.Gazetteer.Both)
+                {
+                    HackneyGazetteerOutOfBoroughAddress = null;
+                }
+            }
+        }
 
         /// <summary>
         /// Filter by UPRN (unique property reference number - unique identifier of the BLPU (Basic Land and Property Unit); a UPRN can have more than one LPI/address. )
@@ -99,7 +116,7 @@ namespace LBHAddressesAPI.UseCases.V1.Search.Models
         ///precedence over the national gazetteer
         ///version.
         /// </summary>
-        public bool HackneyGazetteerOutOfBoroughAddress { get; set; }
+        public bool? HackneyGazetteerOutOfBoroughAddress { get; set; }
 
         /// <summary>
         /// Page defaults to 1 as paging is 1 index based not 0 index based

--- a/HackneyAddressesAPI/UseCases/V1/Search/Models/SearchAddressRequest.cs
+++ b/HackneyAddressesAPI/UseCases/V1/Search/Models/SearchAddressRequest.cs
@@ -91,6 +91,15 @@ namespace LBHAddressesAPI.UseCases.V1.Search.Models
         /// </summary>
         public string AddressStatus { get; set; }
 
+        /// <summary>
+        ///  	wether or not out of borough addresses
+        ///that are present in the local gazetteer
+        ///for services reasons should be returned.
+        ///If yes, the local gazetteer version takes
+        ///precedence over the national gazetteer
+        ///version.
+        /// </summary>
+        public bool HackneyGazetteerOutOfBoroughAddress { get; set; }
 
         /// <summary>
         /// Page defaults to 1 as paging is 1 index based not 0 index based

--- a/LBHAddressesAPITest/Models/SearchAddressRequestTests.cs
+++ b/LBHAddressesAPITest/Models/SearchAddressRequestTests.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using FluentAssertions;
+using NUnit.Framework;
+using Moq;
+using LBHAddressesAPI.UseCases.V1.Search.Models;
+using LBHAddressesAPI.Validation;
+using FluentValidation;
+using FluentValidation.TestHelper;
+using LBHAddressesAPI.Exceptions;
+using LBHAddressesAPI.Helpers;
+
+namespace LBHAddressesAPITest.Models
+{
+    [TestFixture]
+    public class SearchAddressRequestTests
+    {
+        #region Gazetteer
+        [Test]
+        public void GivenNoInputForGazetteer_WhenSearchAddressRequestObjectIsCreated_ItDefaultsToBoth()
+        {
+            var _classUnderTest = new SearchAddressRequest();
+            _classUnderTest.Gazetteer.Should().Equals(GlobalConstants.Gazetteer.Both);
+        }
+
+        [Test]
+        public void GivenInputValueLocalForGazetteer_WhenSearchAddressRequestObjectIsCreated_ItIsSetToLocal()
+        {
+            var _classUnderTest = new SearchAddressRequest() { Gazetteer = GlobalConstants.Gazetteer.Local };
+            _classUnderTest.Gazetteer.Should().Equals(GlobalConstants.Gazetteer.Local);
+        }
+
+        [Test]
+        public void GivenInputValueBothForGazetteer_WhenSearchAddressRequestObjectIsCreated_ItIsSetToBoth()
+        {
+            var _classUnderTest = new SearchAddressRequest() { Gazetteer = GlobalConstants.Gazetteer.Both };
+            _classUnderTest.Gazetteer.Should().Equals(GlobalConstants.Gazetteer.Local);
+        }
+        #endregion
+
+        #region HackneyGazetteerOutOfBoroughAddress
+        [Test] //Gazetteer -> no input, HGOBAddress -> no input
+        public void GivenNoInputValueForGazetteerAndHackneyGazetteerOutOfBoroughAddressParameters_WhenSearchAddressRequestObjectIsCreated_GazetteerIsSetToItsDefaultAndHackneyGazetteerOutOfBoroughAddressIsSetToNullBasedOnThat()
+        {
+            var _classUnderTest = new SearchAddressRequest() { };
+            Assert.Null(_classUnderTest.HackneyGazetteerOutOfBoroughAddress);
+        }
+
+        [Test] //Gazetteer = Both, HGOBAddress -> no input
+        public void GivenGazetteerValueBothAndNoInputForHackneyGazetteerOutOfBoroughAddress_WhenSearchAddressRequestObjectIsCreated_HackneyGazetteerOutOfBoroughAddressIsSetToNull()
+        {
+            var _classUnderTest = new SearchAddressRequest() { Gazetteer = GlobalConstants.Gazetteer.Both };
+            Assert.Null(_classUnderTest.HackneyGazetteerOutOfBoroughAddress);
+        }
+
+        [Test] //Gazetteer = Local, HGOBAddress -> no input
+        public void GivenGazetteerValueLocalAndNoInputForHackneyGazetteerOutOfBoroughAddress_WhenSearchAddressRequestObjectIsCreated_HackneyGazetteerOutOfBoroughAddressIsSetToFalse()
+        {
+            var _classUnderTest = new SearchAddressRequest() { Gazetteer = GlobalConstants.Gazetteer.Local };
+            Assert.AreEqual(_classUnderTest.HackneyGazetteerOutOfBoroughAddress, false);
+        }
+
+        [TestCase(GlobalConstants.Gazetteer.Both, false)]
+        [TestCase(GlobalConstants.Gazetteer.Both, true)]
+        [TestCase(GlobalConstants.Gazetteer.Local, false)]
+        [TestCase(GlobalConstants.Gazetteer.Local, true)]
+        public void GivenAHackneyGazetteerOutOfBoroughAddressInputValueAndAnyGazetteerValue_WhenSearchAddressRequestObjectIsCreated_HackneyGazetteerOutOfBoroughAddressIsSetToWhateverItsInputWas(GlobalConstants.Gazetteer gazetteer, bool? hackneyGazetteerOutOfBoroughAddress)
+        {
+            var _classUnderTest = new SearchAddressRequest() { Gazetteer = gazetteer, HackneyGazetteerOutOfBoroughAddress = hackneyGazetteerOutOfBoroughAddress };
+            Assert.AreEqual(_classUnderTest.HackneyGazetteerOutOfBoroughAddress, hackneyGazetteerOutOfBoroughAddress);
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void GivenNoInputForGazetteerAndInputValueForHackneyGazetteerOutOfBoroughAddress_WhenSearchAddressRequestObjectIsCreated_HackneyGazetteerOutOfBoroughAddressIsSetToWhateverItsInputWas(bool? hackneyGazetteerOutOfBoroughAddress)
+        {
+            var _classUnderTest = new SearchAddressRequest() { HackneyGazetteerOutOfBoroughAddress = hackneyGazetteerOutOfBoroughAddress };
+            Assert.AreEqual(_classUnderTest.HackneyGazetteerOutOfBoroughAddress, hackneyGazetteerOutOfBoroughAddress);
+        }
+        #endregion
+
+    }
+}


### PR DESCRIPTION
What:
- Implemented the 'Out Of Borough Addresses' Filter parameter.
- Configured the default values so that if Gazetteer is Both, the 'Out Of Borough Addresses' are included.
- Configured the default values so that if Gazetteer is Local 'Out Of Borough Addresses' are excluded.
- Defaults can be overriden by input.

Why:
- In the Models tests for SearchAddressRequest object, I dithched the 'Fluent Assertions' because it has a bug where it thinks that the default value for the (bool?) type is false. While it is not - it's actually null. This made it so a test would always pass regardless of implementation.
- Tested the cases where input overrides the defaults. Not sure if I should have done this, but my reasoning was that if in the future anyone ever messes with implementation, then there is a possibillity that could set the defaults in a way, where upon constructing a request object, they wouldn't be overriden. But then again, you could say that against most stuff, so this one is up for debate - I'm willing to remove those tests if they are deemed unneccessary. (I actually want to have a disscussion on this one)

Notes:
Jira Tickets: [APIF-278], [APIF-279]

[APIF-278]: https://hackney.atlassian.net/browse/APIF-278